### PR TITLE
WindowCtrlWin: refactor

### DIFF
--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -81,7 +81,7 @@ QString WindowCtrlWin::getProcessName( qint64 pid )
 {
     HANDLE proc = OpenProcess( PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid );
     char name[ 256 ];
-    GetModuleBaseNameA( proc, NULL, name, 256);
+    GetModuleBaseNameA( proc, nullptr, name, 256);
 
     return QString( name );
 }

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -89,7 +89,7 @@ BOOL CALLBACK   WindowCtrlWin::enumWindowsTitleProc( HWND hwnd, LPARAM lParam )
 {
     char buffer[ 128 ];
     int written = GetWindowTextA( hwnd, buffer, 128 );
-    if( written && strstr( buffer, (char*)lParam ) != NULL )
+    if( written && strstr( buffer, (char*)lParam ) != nullptr )
     {
         m_tb_windows.append( (quint64)hwnd );
     }
@@ -105,10 +105,10 @@ bool    WindowCtrlWin::findWindow( qint64 pid )
 {
     HandleData data;
     data.pid = pid;
-    data.hwnd = 0;
+    data.hwnd = nullptr;
     EnumWindows( &enumWindowsPidProc, (LPARAM)&data );
 
-    if( data.hwnd == 0 )
+    if( data.hwnd == nullptr )
     {
         return false;
     }
@@ -148,7 +148,7 @@ BOOL CALLBACK   WindowCtrlWin::enumWindowsPidProc( HWND hwnd, LPARAM lParam )
  */
 BOOL    WindowCtrlWin::isMainWindow( HWND hwnd )
 {
-    return GetWindow( hwnd, GW_OWNER ) == (HWND)0 && IsWindowVisible( hwnd );
+    return GetWindow( hwnd, GW_OWNER ) == nullptr && IsWindowVisible( hwnd );
 }
 
 

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -9,6 +9,11 @@
 #include <CommCtrl.h>
 
 /*
+ * Standard library includes
+ */
+#include <array>
+
+/*
  * Qt includes
  */
 #include <QCoreApplication>
@@ -87,9 +92,9 @@ bool    WindowCtrlWin::findWindow( const QString& title )
  */
 BOOL CALLBACK   WindowCtrlWin::enumWindowsTitleProc( HWND hwnd, LPARAM lParam )
 {
-    char buffer[ 128 ];
-    int written = GetWindowTextA( hwnd, buffer, 128 );
-    if( written && strstr( buffer, (char*)lParam ) != nullptr )
+    std::array<char, 128> buffer;
+    int written = GetWindowTextA( hwnd, buffer.data(), int(buffer.size()) );
+    if( written && strstr( buffer.data(), (char*)lParam ) != nullptr )
     {
         m_tb_windows.append( (quint64)hwnd );
     }

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -18,12 +18,6 @@
  */
 #include <QCoreApplication>
 
-/*
- *  Statics
- */
-quint64 WindowCtrlWin::m_tb_window;
-QList< quint64 >  WindowCtrlWin::m_tb_windows;
-
 
 /*
  *  Constructor

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -108,10 +108,10 @@ BOOL CALLBACK   WindowCtrlWin::enumWindowsTitleProc( HWND hwnd, LPARAM lParam )
  */
 bool    WindowCtrlWin::findWindow( qint64 pid )
 {
-    HandleData data;
+    EnumWindowsPidProcData data;
     data.pid = pid;
     data.hwnd = nullptr;
-    EnumWindows( &enumWindowsPidProc, (LPARAM)&data );
+    EnumWindows( &enumWindowsPidProc, reinterpret_cast<LPARAM>(&data) );
 
     if( data.hwnd == nullptr )
     {
@@ -132,7 +132,7 @@ bool    WindowCtrlWin::findWindow( qint64 pid )
  */
 BOOL CALLBACK   WindowCtrlWin::enumWindowsPidProc( HWND hwnd, LPARAM lParam )
 {
-    HandleData& data = *(HandleData*)lParam;
+    auto& data = *reinterpret_cast<EnumWindowsPidProcData*>(lParam);
     unsigned long pid = 0;
 
     GetWindowThreadProcessId( hwnd, &pid );

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -159,7 +159,7 @@ void    WindowCtrlWin::displayWindowElements( const QString& title )
 {
     findWindow( title );
 
-    foreach( quint64 win_id, getWinIds() )
+    for( quint64 win_id: getWinIds() )
     {
         emit signalConsole( QString( "Found: XID %1" ).arg( win_id ) );
     }

--- a/app/SysTray-X/windowctrl-win.cpp
+++ b/app/SysTray-X/windowctrl-win.cpp
@@ -76,7 +76,9 @@ bool    WindowCtrlWin::findWindow( const QString& title )
 {
     m_tb_windows = QList< quint64 >();
 
-    EnumWindows( &enumWindowsTitleProc, (LPARAM)(LPSTR)( title.toStdString().c_str() ) );
+    EnumWindowsTitleProcData data{ *this, title.toStdString() };
+
+    EnumWindows( &enumWindowsTitleProc, reinterpret_cast<LPARAM>(&data) );
 
     if( m_tb_windows.length() == 0 )
     {
@@ -92,11 +94,12 @@ bool    WindowCtrlWin::findWindow( const QString& title )
  */
 BOOL CALLBACK   WindowCtrlWin::enumWindowsTitleProc( HWND hwnd, LPARAM lParam )
 {
+    auto& data = *reinterpret_cast<EnumWindowsTitleProcData*>(lParam);
     std::array<char, 128> buffer;
     int written = GetWindowTextA( hwnd, buffer.data(), int(buffer.size()) );
-    if( written && strstr( buffer.data(), (char*)lParam ) != nullptr )
+    if( written && strstr( buffer.data(), data.title.c_str() ) != nullptr )
     {
-        m_tb_windows.append( (quint64)hwnd );
+        data.window_ctrl.m_tb_windows.append( (quint64)hwnd );
     }
 
     return TRUE;

--- a/app/SysTray-X/windowctrl-win.h
+++ b/app/SysTray-X/windowctrl-win.h
@@ -206,12 +206,12 @@ class WindowCtrlWin : public QObject
         /**
          * @brief m_tb_window. The Thunderbird window.
          */
-        static quint64  m_tb_window;
+        quint64  m_tb_window;
 
         /**
          * @brief m_tb_window. The Thunderbird windows.
          */
-        static QList< quint64 >  m_tb_windows;
+        QList< quint64 >  m_tb_windows;
 };
 
 #endif // WINDOWCTRLWIN_H

--- a/app/SysTray-X/windowctrl-win.h
+++ b/app/SysTray-X/windowctrl-win.h
@@ -10,9 +10,19 @@
 #include <Windows.h>
 
 /*
+ *  Standard library includes
+ */
+#include <string>
+
+/*
  *  Qt includes
  */
 #include <QObject>
+
+/*
+ *  Forward declarations
+ */
+class WindowCtrlWin;
 
 /**
  * @brief The WindowCtrlWin class
@@ -27,6 +37,12 @@ class WindowCtrlWin : public QObject
         {
             unsigned long   pid;
             HWND            hwnd;
+        };
+
+        struct EnumWindowsTitleProcData
+        {
+            WindowCtrlWin&      window_ctrl;
+            const std::string   title;
         };
 
     public:

--- a/app/SysTray-X/windowctrl-win.h
+++ b/app/SysTray-X/windowctrl-win.h
@@ -23,7 +23,7 @@ class WindowCtrlWin : public QObject
 
     private:
 
-        struct HandleData
+        struct EnumWindowsPidProcData
         {
             unsigned long   pid;
             HWND            hwnd;


### PR DESCRIPTION
* make `m_tb_window(s)` members non-static --> more consistent with `WindowCtrlUnix`
* use some modern c++ features
