### PR TITLE
Add AUR install option for arch linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ sudo dnf install systray-x-minimal
 
 ### Arch
 
+#### AUR
+A `git` package is available in the user repository (KDE Plasma version). To install it, just use some AUR helper, like yay:
+
+`yay -S systray-x-git`
+
 #### Repository
 
 Installing the repository:


### PR DESCRIPTION
I don't know the author of the package, but his email is in pkgbuild: 

`Maintainer: Zoltan Guba <zoltan.guba@gubamm.hu>`

All credits are his.