### PR TITLE
Fix hang when getting Window Frame Extensions

### DIFF
--- a/app/SysTray-X/SysTray-X-lib-x11/systray-x-lib-x11.cpp
+++ b/app/SysTray-X/SysTray-X-lib-x11/systray-x-lib-x11.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>
+#include <time.h>
 
 /*
  *  X11 includes
@@ -394,7 +395,7 @@ void    SendEvent( void* display, quint64 window, const char* msg_type,
 /*
  *  Get the frame extensions
  */
-void    GetWindowFrameExtensions( void *display, quint64 window, long* left, long* top, long* right, long* bottom )
+void    GetWindowFrameExtensions( void* display, quint64 window, long* left, long* top, long* right, long* bottom )
 {
     Display* dsp = (Display*)display;
 
@@ -410,22 +411,39 @@ void    GetWindowFrameExtensions( void *display, quint64 window, long* left, lon
     *bottom = 0;
 
     /*
-     *   Get the frame extentions
+     *   Get the frame extensions
      */
     Atom type;
     int format;
     unsigned long remain;
     unsigned long len;
     unsigned char* list = NULL;
-    XEvent event;
+    bool ok;
 
-    while( XGetWindowProperty( dsp, window, prop, 0, 4, False, AnyPropertyType,
-                &type, &format, &len, &remain, &list ) != Success || len != 4 || remain != 0 )
+    const struct timespec ts = {
+        .tv_sec = 0,
+        .tv_nsec = 50000000,
+    };
+
+    for( int i = 0; i < 5; i++ )
     {
-        XNextEvent( dsp, &event );
+        ok = XGetWindowProperty( dsp, window, prop, 0, 4, False, AnyPropertyType,
+                &type, &format, &len, &remain, &list ) == Success && len == 4 && remain == 0;
+        if( ok )
+        {
+            break;
+        }
+
+        if( list )
+        {
+            XFree( list );
+            list = NULL;
+        }
+
+        clock_nanosleep( CLOCK_MONOTONIC, 0, &ts, NULL );
     }
 
-    if( list && len == 4 )
+    if( ok && list )
     {
         long* extents = (long*)list;
         *left = extents[ 0 ];


### PR DESCRIPTION
The whole application (including the debug window) would hang randomly with no apparent cause, making the X button in Thunderbird unresponsive.

The following was observed after attaching gdb:
```
[...]
#2  0x00007ffb577ec90a in xcb_wait_for_event () at /lib/x86_64-linux-gnu/libxcb.so.1
#3  0x00007ffb58ecec08 in _XReadEvents () at /lib/x86_64-linux-gnu/libX11.so.6
#4  0x00007ffb58ebd758 in XNextEvent () at /lib/x86_64-linux-gnu/libX11.so.6
#5  0x000055ad74d47d2b in GetWindowFrameExtensions(void*, unsigned long long, long*, long*, long*, long*) ()
#6  0x000055ad74d3c351 in WindowCtrlUnix::updatePositions() ()
#7  0x000055ad74d38718 in WindowCtrl::slotWindowState(Preferences::WindowState) ()
[...]
```

It appears that sometimes the call to XGetWindowProperty() in GetWindowFrameExtensions() succeeds, but len == 0, which results in XNextEvent() being called, waiting for an event that is never received.
This presumably happens because the WM does not have the frame extensions ready when the request is made.

It is not clear why XNextEvent() is being called in the first place, as we are not handling any events from X in that function.

Instead, a loop was added that tries up to five times to get the window frame extensions, waiting for 50ms between calls.

This shouldn't cause any significant slowdown, as most calls will succeed within one or two iterations, and it will prevent hangs if the calls fail all five times.