### PR TITLE
Update the Arch installation instructions in the README according to the new `systray-x` Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ This is a split package that will offer you to either install the [systray-x-com
 sudo pacman -S systray-x
 ```
 
-Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if they already know the one they want to install.  
+Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if you already know the one you want to install.  
 Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
 
 ### CentOS

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ sudo dnf install systray-x-minimal
 
 #### Package
 
-Install the `systray-x` package from the [community] Arch repository.  
+Install the `systray-x` package from the Arch repo.  
 This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ sudo dnf install systray-x-minimal
 #### Package
 
 Install the `systray-x` package from the Arch repo.  
-This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the specific build option and dependencies for a proper integration with KDE.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/extra/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and enable the `gnome-shell-extension-appindicator` for a proper integration with Gnome) or the [systray-x-kde](https://archlinux.org/packages/extra/x86_64/systray-x-kde/) package which includes specific options and dependencies for a proper integration with KDE.  
 
 ```bash
 sudo pacman -S systray-x
 ```
 
-Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if you already know the one you want to install.  
+You can directly install the `systray-x-common` or the `systray-x-kde` package instead, if you already know the one you want to install.  
 Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
 
 ### CentOS

--- a/README.md
+++ b/README.md
@@ -327,49 +327,17 @@ sudo dnf install systray-x-minimal
 
 ### Arch
 
-#### AUR
-A `git` package is available in the user repository (KDE Plasma version). To install it, just use some AUR helper, like yay:
-
-`yay -S systray-x-git`
-
-#### Repository
-
-Installing the repository:
-
-```bash
-wget -q https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64/home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
-sudo pacman-key --add home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
-sudo pacman-key --lsign-key BEEF5C3607D86FE9
-sudo echo -e "\n[home_Ximi1970_Mozilla_Add-ons_Arch_Arch]\nSigLevel = PackageOptional\nServer = https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64" | sudo tee -a /etc/pacman.conf 
-sudo pacman -Syyu
-```
-
 #### Package
 
-Installing the SysTray-X addon and companion app package:
-
-###### KDE
+Install the `systray-x` package from the [community] Arch repository.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
 
 ```bash
 sudo pacman -S systray-x
 ```
 
-###### GNOME
-
-```bash
-sudo pacman -S systray-x-gnome
-sudo pacman -S gnome-tweaks
-```
-Please use `Tweaks` to activate the gnome shell extension `Kstatusnotifieritem/appindicator support` or reboot the system.
-
-
-
-###### XFCE / Others (non-KDE, non-GNOME)
-
-```bash
-sudo pacman -S systray-x-minimal
-```
-
+Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if they already know the one they want to install.  
+Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
 
 ### CentOS
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ sudo dnf install systray-x-minimal
 #### Package
 
 Install the `systray-x` package from the Arch repo.  
-This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/extra/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and enable the `gnome-shell-extension-appindicator` for a proper integration with Gnome) or the [systray-x-kde](https://archlinux.org/packages/extra/x86_64/systray-x-kde/) package which includes specific options and dependencies for a proper integration with KDE.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/extra/x86_64/systray-x-common/) package which is suitable for any DE/WM except KDE (Gnome users need to install and enable the `gnome-shell-extension-appindicator` for a proper integration with Gnome) or the [systray-x-kde](https://archlinux.org/packages/extra/x86_64/systray-x-kde/) package which includes specific options and dependencies for a proper integration with KDE.  
 
 ```bash
 sudo pacman -S systray-x

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ sudo dnf install systray-x-minimal
 #### Package
 
 Install the `systray-x` package from the Arch repo.  
-This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the specific build option and dependencies for a proper integration with KDE.  
 
 ```bash
 sudo pacman -S systray-x


### PR DESCRIPTION
Hi,

First of all, thanks a lot for your amazing work with `systray-x`!

In addition of the already existing [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) AUR package (packaged by "toxin"), I created a [systray-x](https://gitlab.archlinux.org/archlinux/packaging/packages/systray-x) package in the Arch [extra] repository.  I hope it's okay for you!
This is a split package that offers to either install the [systray-x-common](https://archlinux.org/packages/extra/x86_64/systray-x-common/) package (which supersedes the [systray-x Minimal](https://github.com/Ximi1970/systray-x/blob/develop/dist/arch/minimal/) and the [systray-x Gnome](https://github.com/Ximi1970/systray-x/blob/develop/dist/arch/gnome/) packages) or the [systray-x-kde](https://archlinux.org/packages/extra/x86_64/systray-x-kde/) package (which supersedes the [systray-x KDE](https://github.com/Ximi1970/systray-x/blob/develop/dist/arch/kde/) package).  
  
This PR aims to update the README accordingly. 
I allowed myself to overwrite the "#### Repository" section as I assume those new "official" `systray-x` Arch packages supersede that section.
That also means you could remove the arch PKGBUILDs from this GitHub repo if you want, since this is now managed directly on Arch side. That's less to manage on your side :smile_cat: 

I remain available if you have any question or if you want me to make any change to the PR :)