### PR TITLE
Add compatibility with Thunderbird 115

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ This is a split package that will offer you to either install the [systray-x-com
 sudo pacman -S systray-x
 ```
 
-Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if they already know the one they want to install.  
+Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if you already know the one you want to install.  
 Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
 
 ### CentOS

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ sudo dnf install systray-x-minimal
 
 #### Package
 
-Install the `systray-x` package from the [community] Arch repository.  
+Install the `systray-x` package from the Arch repo.  
 This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -327,49 +327,17 @@ sudo dnf install systray-x-minimal
 
 ### Arch
 
-#### AUR
-A `git` package is available in the user repository (KDE Plasma version). To install it, just use some AUR helper, like yay:
-
-`yay -S systray-x-git`
-
-#### Repository
-
-Installing the repository:
-
-```bash
-wget -q https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64/home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
-sudo pacman-key --add home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
-sudo pacman-key --lsign-key BEEF5C3607D86FE9
-sudo echo -e "\n[home_Ximi1970_Mozilla_Add-ons_Arch_Arch]\nSigLevel = PackageOptional\nServer = https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64" | sudo tee -a /etc/pacman.conf 
-sudo pacman -Syyu
-```
-
 #### Package
 
-Installing the SysTray-X addon and companion app package:
-
-###### KDE
+Install the `systray-x` package from the [community] Arch repository.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
 
 ```bash
 sudo pacman -S systray-x
 ```
 
-###### GNOME
-
-```bash
-sudo pacman -S systray-x-gnome
-sudo pacman -S gnome-tweaks
-```
-Please use `Tweaks` to activate the gnome shell extension `Kstatusnotifieritem/appindicator support` or reboot the system.
-
-
-
-###### XFCE / Others (non-KDE, non-GNOME)
-
-```bash
-sudo pacman -S systray-x-minimal
-```
-
+Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if they already know the one they want to install.  
+Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
 
 ### CentOS
 

--- a/README.md
+++ b/README.md
@@ -327,17 +327,49 @@ sudo dnf install systray-x-minimal
 
 ### Arch
 
+#### AUR
+A `git` package is available in the user repository (KDE Plasma version). To install it, just use some AUR helper, like yay:
+
+`yay -S systray-x-git`
+
+#### Repository
+
+Installing the repository:
+
+```bash
+wget -q https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64/home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
+sudo pacman-key --add home_Ximi1970_Mozilla_Add-ons_Arch_Arch.key
+sudo pacman-key --lsign-key BEEF5C3607D86FE9
+sudo echo -e "\n[home_Ximi1970_Mozilla_Add-ons_Arch_Arch]\nSigLevel = PackageOptional\nServer = https://download.opensuse.org/repositories/home:/Ximi1970:/Mozilla:/Add-ons:/Arch/Arch/x86_64" | sudo tee -a /etc/pacman.conf 
+sudo pacman -Syyu
+```
+
 #### Package
 
-Install the `systray-x` package from the Arch repo.  
-This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the specific build option and dependencies for a proper integration with KDE.  
+Installing the SysTray-X addon and companion app package:
+
+###### KDE
 
 ```bash
 sudo pacman -S systray-x
 ```
 
-Of course, you can directly install the `systray-x-common` or the `systray-x-kde` package if you already know the one you want to install.  
-Alternatively, there's a [systray-x-git](https://aur.archlinux.org/packages/systray-x-git) package available in the AUR.
+###### GNOME
+
+```bash
+sudo pacman -S systray-x-gnome
+sudo pacman -S gnome-tweaks
+```
+Please use `Tweaks` to activate the gnome shell extension `Kstatusnotifieritem/appindicator support` or reboot the system.
+
+
+
+###### XFCE / Others (non-KDE, non-GNOME)
+
+```bash
+sudo pacman -S systray-x-minimal
+```
+
 
 ### CentOS
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ sudo dnf install systray-x-minimal
 #### Package
 
 Install the `systray-x` package from the Arch repo.  
-This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the KDE specific build option and dependencies.  
+This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/community/x86_64/systray-x-common/) package which is suitable for any DE/WM but KDE (Gnome users need to install and activate the `gnome-shell-extension-appindicator` for a proper integration) or the [systray-x-kde](https://archlinux.org/packages/community/x86_64/systray-x-kde/) package which includes the specific build option and dependencies for a proper integration with KDE.  
 
 ```bash
 sudo pacman -S systray-x

--- a/dist/arch/gnome/PKGBUILD
+++ b/dist/arch/gnome/PKGBUILD
@@ -12,7 +12,7 @@ depends=(
   'qt5-base'
   'gnome-shell-extension-appindicator'
   'thunderbird>=68'
-  'thunderbird<114'
+  'thunderbird<116'
 )
 makedepends=(
   'git'

--- a/dist/arch/kde/PKGBUILD
+++ b/dist/arch/kde/PKGBUILD
@@ -12,7 +12,7 @@ depends=(
   'qt5-base'
   'knotifications'
   'thunderbird>=68'
-  'thunderbird<114'
+  'thunderbird<116'
 )
 makedepends=(
   'git'

--- a/dist/arch/minimal/PKGBUILD
+++ b/dist/arch/minimal/PKGBUILD
@@ -11,7 +11,7 @@ license=(MPL-2.0)
 depends=(
   'qt5-base'
   'thunderbird>=68'
-  'thunderbird<114'
+  'thunderbird<116'
 )
 makedepends=(
   'git'

--- a/dist/deb/gnome/debian.control
+++ b/dist/deb/gnome/debian.control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 4.1.16), zip, g++, libx11-dev, qt5-qmake, qtbase5-d
 
 Package: systray-x-gnome
 Architecture: any
-Depends: ${shlibs:Depends}, gnome-shell-extension-appindicator, thunderbird (>= 1:68), thunderbird (< 1:114)
+Depends: ${shlibs:Depends}, gnome-shell-extension-appindicator, thunderbird (>= 1:68), thunderbird (< 1:116)
 Description: SysTray-X is a system tray extension for Thunderbird 68+ (GNOME).
  This version is optimized for the GNOME desktop.
  The add-on uses the WebExtension API's to control an external system

--- a/dist/deb/kde/debian.control
+++ b/dist/deb/kde/debian.control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 4.1.16), zip, g++, libx11-dev, qt5-qmake, qtbase5-d
 
 Package: systray-x
 Architecture: any
-Depends: ${shlibs:Depends}, thunderbird (>= 1:68), thunderbird (< 1:114)
+Depends: ${shlibs:Depends}, thunderbird (>= 1:68), thunderbird (< 1:116)
 Description: SysTray-X is a system tray extension for Thunderbird 68+ (KDE).
  This version is optimized for the KDE desktop.
  The add-on uses the WebExtension API's to control an external system

--- a/dist/deb/minimal/debian.control
+++ b/dist/deb/minimal/debian.control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 4.1.16), zip, g++, libx11-dev, qt5-qmake, qtbase5-d
 
 Package: systray-x-minimal
 Architecture: any
-Depends: ${shlibs:Depends}, thunderbird (>= 1:68), thunderbird (< 1:114)
+Depends: ${shlibs:Depends}, thunderbird (>= 1:68), thunderbird (< 1:116)
 Description: SysTray-X is a system tray extension for Thunderbird 68+ (non-GNOME,non-KDE).
  This version is for non-KDE and non-GNOME desktops.
  The add-on uses the WebExtension API's to control an external system

--- a/dist/rpm/gnome/systray-x-gnome.spec
+++ b/dist/rpm/gnome/systray-x-gnome.spec
@@ -33,10 +33,10 @@ BuildRequires:  pkgconfig(x11)
 Requires:       gnome-shell-extension-appindicator
 %if 0%{?fedora_version} || 0%{?centos_version}
 Requires:       thunderbird >= 68
-Requires:       thunderbird < 114
+Requires:       thunderbird < 116
 %else
 Requires:       MozillaThunderbird >= 68
-Requires:       MozillaThunderbird < 114
+Requires:       MozillaThunderbird < 116
 %endif
 
 %description

--- a/dist/rpm/kde/systray-x.spec
+++ b/dist/rpm/kde/systray-x.spec
@@ -34,12 +34,12 @@ BuildRequires:  pkgconfig(x11)
 BuildRequires:  kf5-knotifications-devel
 Requires:       kf5-knotifications
 Requires:       thunderbird >= 68
-Requires:       thunderbird < 114
+Requires:       thunderbird < 116
 %else
 BuildRequires:  knotifications-devel
 Requires:       libKF5Notifications5
 Requires:       MozillaThunderbird >= 68
-Requires:       MozillaThunderbird < 114
+Requires:       MozillaThunderbird < 116
 %endif
 
 %description

--- a/dist/rpm/minimal/systray-x-minimal.spec
+++ b/dist/rpm/minimal/systray-x-minimal.spec
@@ -32,10 +32,10 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(x11)
 %if 0%{?fedora_version} || 0%{?centos_version}
 Requires:       thunderbird >= 68
-Requires:       thunderbird < 114
+Requires:       thunderbird < 116
 %else
 Requires:       MozillaThunderbird >= 68
-Requires:       MozillaThunderbird < 114
+Requires:       MozillaThunderbird < 116
 %endif
 
 %description

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -10,7 +10,7 @@
     "gecko": {
       "id": "systray-x@Ximi1970",
       "strict_min_version": "68.0",
-      "strict_max_version": "113.*"
+      "strict_max_version": "115.*"
     }
   },
 


### PR DESCRIPTION
This PR aims to add compatibility/support for Thunderbird 115 (tested successfully on Arch Linux).  

Also, creating a new tag (and rebuild the different binaries) after this PR is merged could be great since Thunderbird 115 has been tagged as the latest stable Thunderbird release and `systray-x 0.9.2` (latest tag available at the time I'm writing this comment) doesn't support it (see #147).
In the mean time, while waiting for a new tag and since [Thunderbird 115 has *already* been pushed in Arch's (testing) repo](https://archlinux.org/packages/extra-testing/x86_64/thunderbird/), I added a [patch](https://gitlab.archlinux.org/archlinux/packaging/packages/systray-x/-/commit/2b8ea67fd1f3124c5a1f6918f60e127d3e49e383) to the Arch PKGBUILD so `systray-x` won't break after updating Thunderbird for Arch users. 

*PS: On a side note, allow me to remind you about another PR I opened a few months ago: #145*