### PR TITLE
Document the usage of MOZ_ENABLE_WAYLAND=0 in README to use systray-x under Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ and change the `Exec` line into this:
 Exec=env GDK_BACKEND=x11 thunderbird %u
 ```
 
+If `GDK_BACKEND=x11` doesn't work, one could try the following instead:
+```bash
+env MOZ_ENABLE_WAYLAND=0 thunderbird
+```
 
 ## Linux distributions
 
@@ -454,7 +458,7 @@ Please use `gnome-extensions` to enable the gnome shell extension `appindicators
 sudo pacman -S systray-x-minimal
 ```
 
-#### AUR alternative install (by Antiz96)
+#### Alternative install (by Antiz96)
 
 Install the `systray-x` package from the Arch repo.
 This is a split package that will offer you to either install the [systray-x-common](https://archlinux.org/packages/extra/x86_64/systray-x-common/) package which is suitable for any DE/WM except KDE (Gnome users need to install and enable the `gnome-shell-extension-appindicator` for a proper integration with Gnome) or the [systray-x-kde](https://archlinux.org/packages/extra/x86_64/systray-x-kde/) package which includes specific options and dependencies for a proper integration with KDE.


### PR DESCRIPTION
Since version 128, Thunderbird uses Wayland by default. To get the `systray-x` addon working properly under Arch on Sway with Thunderbird 128, I had to use `env MOZ_ENABLE_WAYLAND=0 thunderbird` (instead of `env GDK_BACKEND=x11 thunderbird`, see [this comment](https://github.com/Ximi1970/systray-x/issues/199#issuecomment-2351796927)).

To be honest, it seems DE/Compositor specific (somehow). For instance, `env GDK_BACKEND=x11 thunderbird` still works in KDE, but doesn't seem to work anymore in Sway (with Thunderbird 128+ at least, it was working fine with previous version of Thunderbird though).
Regardless, I think it doesn't hurt documenting `env MOZ_ENABLE_WAYLAND=0 thunderbird` in the README in case people face the same issue I got on Sway with Thunderbird 128+.

I also removed the `AUR` mention for the "Alternative install" in the Arch section as it is not about an AUR package but an [official Arch package from the [extra] repository](https://archlinux.org/packages/extra/x86_64/systray-x-kde/).