### PR TITLE
manifest: Remove strict_max_version

### DIFF
--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -9,8 +9,7 @@
   "applications": {
     "gecko": {
       "id": "systray-x@Ximi1970",
-      "strict_min_version": "91.0",
-      "strict_max_version": "998.0"
+      "strict_min_version": "91.0"
     }
   },
 


### PR DESCRIPTION
It's optional. Documentation says "Usually only needed if Experiments are included".
Link: https://developer.thunderbird.net/add-ons/mailextensions